### PR TITLE
cache darkmode flag, restore early

### DIFF
--- a/src/UserState.js
+++ b/src/UserState.js
@@ -74,6 +74,17 @@ export const useUiState = () => {
     !!process.env.NAB_DARK_MODE
   )
 
+  useEffect(() => {
+    try {
+      if(darkMode)
+        localStorage.setItem("darkMode", true)
+      else
+        localStorage.removeItem("darkMode")
+    }
+    catch(e) {
+    }
+  }, [darkMode])
+
   const quoteSelected = () => quoteText(window.getSelection().toString())
   const setQuotedText = text => setQuote(quoteText(text))
 

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,13 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>notabug: the back page of the internet</title>
+    <script>
+      try {
+        if(localStorage.getItem("darkMode") === "true")
+          document.documentElement.classList.add("darkmode")
+      }
+      catch(e) {}
+    </script>
   </head>
   <body class="loggedin subscriber">
     !!!CONTENT!!!


### PR DESCRIPTION
NB: The "cache only if different from default" logic would not work when NAB_DARK_MODE is set (can't access process.env for early mode switch). That's why the darkmode flag is always written to localStorage when it's `true`, and deleted if not.